### PR TITLE
PR: Fix get standard iconsize

### DIFF
--- a/qtapputils/icons.py
+++ b/qtapputils/icons.py
@@ -70,7 +70,7 @@ class IconManager:
         return QSize(*self._icon_sizes[size])
 
     @staticmethod
-    def get_standard_icon(constant):
+    def get_standard_icon(constant: str) -> QIcon:
         """
         Return a QIcon of a standard pixmap.
 
@@ -81,7 +81,8 @@ class IconManager:
         style = QApplication.instance().style()
         return style.standardIcon(constant)
 
-    def get_standard_iconsize(constant: 'str'):
+    @staticmethod
+    def get_standard_iconsize(constant: 'str') -> int:
         """
         Return the standard size of various component of the gui.
 

--- a/qtapputils/tests/test_icons.py
+++ b/qtapputils/tests/test_icons.py
@@ -16,7 +16,7 @@ import os.path as osp
 
 # ---- Third party imports
 import pytest
-from qtpy.QtGui import QImage
+from qtpy.QtGui import QImage, QIcon
 
 # ---- Local imports
 from qtapputils.colors import RED, YELLOW
@@ -78,6 +78,23 @@ def test_get_local_icons(qtbot, tmp_path):
     icon = IM.get_icon('alert')
     expected_home_img = osp.join(osp.dirname(__file__), 'alert_icon.tiff')
     assert QImage(expected_home_img) == icon.pixmap(48).toImage()
+
+
+def test_get_standard_icon(qtbot):
+    """
+    Test that getting standard icon is working as expected.
+    """
+    IM = IconManager()
+    assert isinstance(IM.get_standard_icon('SP_MessageBoxCritical'), QIcon)
+
+
+def test_get_standard_iconsize(qtbot):
+    """
+    Test that getting standard icon size is working as expected.
+    """
+    IM = IconManager()
+    for constant in ['messagebox', 'small']:
+        assert isinstance(IM.get_standard_iconsize(constant), int)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added a missing `staticmethod` decorator to `IconManager.get_standard_iconsize` method.
- Added missing CI tests