### PR TITLE
PR: Add a 'run tasks started' signal to TaskManagerBase and minor behavior change to LIFOTaskManager

### DIFF
--- a/qtapputils/widgets/taskmanagers.py
+++ b/qtapputils/widgets/taskmanagers.py
@@ -54,6 +54,7 @@ class TaskManagerBase(QObject):
     """
     A basic FIFO (First-In, First-Out) task manager.
     """
+    sig_run_tasks_started = Signal()
     sig_run_tasks_finished = Signal()
 
     def __init__(self, verbose: bool = False):
@@ -164,6 +165,8 @@ class TaskManagerBase(QObject):
         """
         self._pending_tasks.extend(self._queued_tasks)
         self._queued_tasks = []
+        if len(self._running_tasks) == 0:
+            self.sig_run_tasks_started.emit()
         self._run_pending_tasks()
 
     def _run_pending_tasks(self):

--- a/qtapputils/widgets/taskmanagers.py
+++ b/qtapputils/widgets/taskmanagers.py
@@ -210,4 +210,3 @@ class LIFOTaskManager(TaskManagerBase):
         self._queued_tasks = []
         self._pending_tasks = []
         super()._add_task(task, callback, *args, **kargs)
-        self._run_tasks()

--- a/qtapputils/widgets/tests/test_taskmanagers.py
+++ b/qtapputils/widgets/tests/test_taskmanagers.py
@@ -16,6 +16,7 @@ from time import sleep
 
 # ---- Third party imports
 import pytest
+from qtpy.QtTest import QSignalSpy
 
 # ---- Local imports
 from qtapputils.widgets import WorkerBase, TaskManagerBase
@@ -67,6 +68,10 @@ def test_run_tasks(task_manager, qtbot):
     def task_callback(data):
         returned_values.append(data)
 
+    # Add spy to the signals.
+    start_signal_spy = QSignalSpy(task_manager.sig_run_tasks_started)
+    end_signal_spy = QSignalSpy(task_manager.sig_run_tasks_finished)
+
     # Add some tasks to the manager.
     task_manager.add_task('get_something', task_callback)
     task_manager.add_task('get_something', task_callback)
@@ -93,6 +98,10 @@ def test_run_tasks(task_manager, qtbot):
     assert returned_values[1] == [1, 2, 3, 4]
     assert returned_values[2] == [1, 2, -19.5, 4]
 
+    # We assert that each signal were called only once.
+    assert len(start_signal_spy) == 1
+    assert len(end_signal_spy) == 1
+
 
 def test_run_tasks_if_busy(task_manager, qtbot):
     """
@@ -103,6 +112,10 @@ def test_run_tasks_if_busy(task_manager, qtbot):
 
     def task_callback(data):
         returned_values.append(data)
+
+    # Add spy to the signals.
+    start_signal_spy = QSignalSpy(task_manager.sig_run_tasks_started)
+    end_signal_spy = QSignalSpy(task_manager.sig_run_tasks_finished)
 
     # Add some tasks to the manager.
     task_manager.add_task('get_something', task_callback)
@@ -148,6 +161,10 @@ def test_run_tasks_if_busy(task_manager, qtbot):
     assert returned_values[0] == [1, 2, 3, 4]
     assert returned_values[1] == [1, 2, 3, 4]
     assert returned_values[2] == [1, 0.512, -19.5, 4]
+
+    # We assert that each signal were called only once.
+    assert len(start_signal_spy) == 1
+    assert len(end_signal_spy) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Now TaskManagerBase  will emit `sig_run_tasks_started` when a new batch of tasks is started. Note that the signal is not emitted when new tasks are added to the queue and pushed as pending tasks while the worker is still running tasks.
- Now `run_tasks` is not systematically called when adding a new task to the `LIFOTaskManager`. This must be called explicitly after adding a task.