### PR TITLE
PR: Workaround a bug in QDoubleSpinBox when 'coma' is used as decimals and thousands separator

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -38,7 +38,7 @@ class DoubleSpinBox(QDoubleSpinBox):
                 return tostr.replace(LOCALE.groupSeparator(), '')
             else:
                 return (
-                    tostr[:-index].replace(LOCALE.groupSeparator(), '') +
+                    tostr[:-index-1].replace(LOCALE.groupSeparator(), '') +
                     tostr[-1-index:]
                     )
 

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -8,14 +8,42 @@
 # -----------------------------------------------------------------------------
 
 # ---- Third party imports
-from qtpy.QtCore import Signal, QObject, QLocale
+from qtpy.QtCore import Signal, QObject, QLocale, Qt
 from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import QDoubleSpinBox, QWidget
 
 LOCALE = QLocale()
 
 
-class RangeSpinBox(QDoubleSpinBox):
+class DoubleSpinBox(QDoubleSpinBox):
+    """
+    A standard qt double spinbox that implements a workaround for
+    the bug described at https://bugreports.qt.io/browse/QTBUG-77939.
+    """
+
+    def textFromValue(self, value: float):
+        """
+        Override qt base method to work around the bug described at
+        https://bugreports.qt.io/browse/QTBUG-77939 when a ',' is
+        used as decimal separator.
+        """
+        from qtpy.QtCore import QLocale
+        LOCALE = QLocale()
+        if self.isGroupSeparatorShown():
+            return LOCALE.toString(value, 'f', self.decimals())
+        else:
+            tostr = LOCALE.toString(value, 'f', self.decimals())
+            index = self.decimals()
+            if index == 0:
+                return tostr.replace(LOCALE.groupSeparator(), '')
+            else:
+                return (
+                    tostr[:-index].replace(LOCALE.groupSeparator(), '') +
+                    tostr[-1-index:]
+                    )
+
+
+class RangeSpinBox(DoubleSpinBox):
     """
     A spinbox that allow to enter values that are lower or higher than the
     minimum and maximum value of the spinbox.
@@ -58,9 +86,9 @@ class RangeSpinBox(QDoubleSpinBox):
 
         num, success = LOCALE.toDouble(value)
         if float(num) > self.maximum():
-            return LOCALE.toString(self.maximum(), 'f', self.decimals())
+            return self.textFromValue(self.maximum())
         else:
-            return LOCALE.toString(self.minimum(), 'f', self.decimals())
+            return self.textFromValue(self.minimum())
 
     def validate(self, value, pos):
         """Override Qt method."""

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # ---- Third party imports
-from qtpy.QtCore import Signal, QObject, QLocale, Qt
+from qtpy.QtCore import Signal, QObject, QLocale
 from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import QDoubleSpinBox, QWidget
 


### PR DESCRIPTION
See https://bugreports.qt.io/browse/QTBUG-77939.

For example, when the same symbol is used as decimal and thousand separator, `textFromValue` returns `100000` for `1000.00` instead of `1000`.

The idea here is to override the `textFromValue` of `QDoubleSpinBox` to implement a workaround.