### PR TITLE
PR: consume Enter or Return key press and release events in QDoubleSpinBox

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------
 
 # ---- Third party imports
-from qtpy.QtCore import Signal, QObject, QLocale
+from qtpy.QtCore import Signal, QObject, QLocale, Qt
 from qtpy.QtGui import QValidator
 from qtpy.QtWidgets import QDoubleSpinBox, QWidget
 
@@ -20,6 +20,24 @@ class DoubleSpinBox(QDoubleSpinBox):
     A standard qt double spinbox that implements a workaround for
     the bug described at https://bugreports.qt.io/browse/QTBUG-77939.
     """
+
+    def keyReleaseEvent(self, event):
+        """
+        Override qt base method to consume key release events so that they are
+        not propagated to the parent.
+        """
+        super().keyReleaseEvent(event)
+        if event.key() in (Qt.Key_Enter, Qt.Key_Return):
+            event.accept()
+
+    def keyPressEvent(self, event):
+        """
+        Override qt base method to consume key press events so that they are
+        not propagated to the parent.
+        """
+        super().keyPressEvent(event)
+        if event.key() in (Qt.Key_Enter, Qt.Key_Return):
+            event.accept()
 
     def textFromValue(self, value: float):
         """

--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -21,13 +21,21 @@ class DoubleSpinBox(QDoubleSpinBox):
     the bug described at https://bugreports.qt.io/browse/QTBUG-77939.
     """
 
+    def __init__(self, parent: QWidget = None,
+                 consume_enter_events: bool = True):
+        super().__init__(parent)
+        # Whether to consume key press and key release events.
+        # See jnsebgosselin/qtapputils#18
+        self.consume_enter_events = consume_enter_events
+
     def keyReleaseEvent(self, event):
         """
         Override qt base method to consume key release events so that they are
         not propagated to the parent.
         """
         super().keyReleaseEvent(event)
-        if event.key() in (Qt.Key_Enter, Qt.Key_Return):
+        if (event.key() in (Qt.Key_Enter, Qt.Key_Return) and
+                self.consume_enter_events):
             event.accept()
 
     def keyPressEvent(self, event):
@@ -36,7 +44,8 @@ class DoubleSpinBox(QDoubleSpinBox):
         not propagated to the parent.
         """
         super().keyPressEvent(event)
-        if event.key() in (Qt.Key_Enter, Qt.Key_Return):
+        if (event.key() in (Qt.Key_Enter, Qt.Key_Return) and
+                self.consume_enter_events):
             event.accept()
 
     def textFromValue(self, value: float):


### PR DESCRIPTION
By default, key press and key release events for the `Enter` or `Return` keys are not consumed by `QDoubleSpinBox` and are propagated to the parent.

We don't want that. If a `QDoubleSpinBox` is added to a dialog for example, if you hit the enter key while the spin box is focused, the event will propagate to the dialog and activate the default button of the dialog.