### PR TITLE
PR: Add "system Info" option in the About widget

### DIFF
--- a/qtapputils/widgets/about.py
+++ b/qtapputils/widgets/about.py
@@ -73,6 +73,7 @@ class AboutDialog(QDialog):
             text += "<p>" + system_info + "</p>"
         text += "</div>"
 
+        self.label = QLabel(text)
         self.label.setWordWrap(True)
         self.label.setAlignment(Qt.AlignTop)
         self.label.setOpenExternalLinks(True)


### PR DESCRIPTION
This is a follow up to PR  #23

![image](https://github.com/user-attachments/assets/1878e4ad-59dd-43b5-be99-63bb766b7963)
