### PR TITLE
PR: Add 'precise' parameter to RangeWidget

### DIFF
--- a/qtapputils/widgets/range.py
+++ b/qtapputils/widgets/range.py
@@ -214,7 +214,8 @@ class RangeWidget(QObject):
 
     def __init__(self, parent: QWidget = None, maximum: float = 99.99,
                  minimum: float = 0, singlestep: float = 0.01,
-                 decimals: int = 2, null_range_ok: bool = True):
+                 decimals: int = 2, null_range_ok: bool = True,
+                 precise: bool = False):
         super().__init__()
         self.decimals = decimals
         self.null_range_ok = null_range_ok
@@ -224,14 +225,14 @@ class RangeWidget(QObject):
 
         self.spinbox_start = RangeSpinBox(
             minimum=minimum, singlestep=singlestep, decimals=decimals,
-            value=minimum)
+            value=minimum, precise=precise)
 
         self.spinbox_start.sig_value_changed.connect(
             lambda: self._handle_value_changed())
 
         self.spinbox_end = RangeSpinBox(
             maximum=maximum, singlestep=singlestep, decimals=decimals,
-            value=maximum)
+            value=maximum, precise=precise)
 
         self.spinbox_end.sig_value_changed.connect(
             lambda: self._handle_value_changed())


### PR DESCRIPTION
Introduces a `precise` boolean parameter to the `RangeWidget` constructor and passes it to the `RangeSpinBox` instances, which already have this parameter in its constructor.

```python
"""
Parameters
    ----------
    precise : bool, optional
        If True (default), the spinbox preserves full float64 precision for
        programmatically set values. If False, it behaves like a standard
        QDoubleSpinBox without storing an internal precise value.
"""
```